### PR TITLE
Prototype pollution fix - checking magic attributes - grpc-js

### DIFF
--- a/packages/grpc-js/test/test-prototype-pollution.ts
+++ b/packages/grpc-js/test/test-prototype-pollution.ts
@@ -24,4 +24,8 @@ describe('loadPackageDefinition', () => {
       loadPackageDefinition({'__proto__.polluted': true} as any);
       assert.notStrictEqual(({} as any).polluted, true);
   });
+  it('Should not allow prototype pollution #2', () => {
+      loadPackageDefinition({'constructor.prototype.polluted': true} as any);
+      assert.notStrictEqual(({} as any).polluted, true);
+  });
 });


### PR DESCRIPTION
### 📊 Metadata *

grpc is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-grpc

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

`// poc.js`
`var grpc =require('grpc')`
`grpc.loadPackageDefinition({'constructor.prototype.polluted': { service: "Yes! Its Polluted" }});`
`console.log({}.polluted)`

Execute the following commands in another terminal:

`npm i grpc # Install affected module`
`node poc.js #  Run the PoC`

Check the Output:

[Function: ServiceClient] { service: 'Yes! Its Polluted' }`

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/99915170-0887ee80-2d28-11eb-8c66-9fbb0beada03.png)

After:
![image](https://user-images.githubusercontent.com/64132745/99915196-379e6000-2d28-11eb-8b0f-0cf584f21463.png)


### 👍 User Acceptance Testing (UAT)

After fix functionality is unaffected.


![grpc-proto-test-1](https://user-images.githubusercontent.com/64132745/99915042-3e78a300-2d27-11eb-9ba6-436969149a90.png)

![grpc-proto-test-2](https://user-images.githubusercontent.com/64132745/99915046-43d5ed80-2d27-11eb-8d57-758bd0b34a61.png)
![grpc-proto-test-3](https://user-images.githubusercontent.com/64132745/99915049-48020b00-2d27-11eb-99db-d7f5b354ae54.png)
![grpc-proto-test-4](https://user-images.githubusercontent.com/64132745/99915054-4cc6bf00-2d27-11eb-85b1-743e1d1d2fe6.png)
![grpc-proto-test-5](https://user-images.githubusercontent.com/64132745/99915051-4b959200-2d27-11eb-9243-c95099cc0497.png)
![grpc-proto-test-6](https://user-images.githubusercontent.com/64132745/99915052-4c2e2880-2d27-11eb-902f-0a1f9115d8e4.png)
![grpc-proto-test-7](https://user-images.githubusercontent.com/64132745/99915053-4c2e2880-2d27-11eb-8cad-e9b67d749cc8.png)
