### PR TITLE
Prototype pollution fix - checking magic attributes - grpc/native-core

### DIFF
--- a/packages/grpc-native-core/index.js
+++ b/packages/grpc-native-core/index.js
@@ -30,6 +30,8 @@ var server = require('./src/server.js');
 
 var common = require('./src/common.js');
 
+var utils = require('./src/utils.js');
+
 var Metadata = require('./src/metadata.js');
 
 var grpc = require('./src/grpc_extension');
@@ -161,9 +163,7 @@ exports.loadPackageDefinition = function loadPackageDefintion(packageDef) {
   for (const serviceFqn in packageDef) {
     const service = packageDef[serviceFqn];
     const nameComponents = serviceFqn.split('.');
-    if (nameComponents.some(comp => comp === '__proto__')) {
-      continue;
-    }
+    utils.disallowProtoPath(nameComponents);
     const serviceName = nameComponents[nameComponents.length-1];
     let current = result;
     for (const packageName of nameComponents.slice(0, -1)) {

--- a/packages/grpc-native-core/src/client.js
+++ b/packages/grpc-native-core/src/client.js
@@ -41,6 +41,8 @@ var Metadata = require('./metadata');
 
 var constants = require('./constants');
 
+var utils = require('./utils');
+
 var EventEmitter = require('events').EventEmitter;
 
 var stream = require('stream');
@@ -992,9 +994,7 @@ exports.makeClientConstructor = function(methods, serviceName,
 
   Object.keys(methods).forEach(name => {
     const attrs = methods[name];
-    if (name === '__proto__') {
-      return;
-    }
+    utils.disallowProtoPath(name);
     if (name.indexOf('$') === 0) {
       throw new Error('Method names cannot start with $');
     }
@@ -1014,7 +1014,7 @@ exports.makeClientConstructor = function(methods, serviceName,
     ServiceClient.prototype.$method_names[attrs.path] = name;
     // Associate all provided attributes with the method
     Object.assign(ServiceClient.prototype[name], attrs);
-    if (attrs.originalName && attrs.originalName !== '__proto__') {
+    if (attrs.originalName && !utils.isProtoPath(attrs.originalName)) {
       ServiceClient.prototype[attrs.originalName] =
         ServiceClient.prototype[name];
     }

--- a/packages/grpc-native-core/src/utils.js
+++ b/packages/grpc-native-core/src/utils.js
@@ -1,0 +1,36 @@
+
+/**
+ * 
+ * ILLEGAL KEYS 
+ */
+var ILLEGAL_KEYS = ['__proto__', 'prototype', 'constructor'];
+
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param key key for check, string.
+ */
+exports.isIllegalKey = function (key) {
+  return ILLEGAL_KEYS.indexOf(key) !== -1;
+}
+
+/**
+ * Returns true if path is/has unsafe keys.
+ * @param path 
+ */
+exports.isProtoPath = function (path) {
+  return Array.isArray(path)
+    ? path.some(module.exports.isIllegalKey)
+    : typeof path === "string"
+      ? module.exports.isIllegalKey(path)
+      : false;
+}
+
+/**
+ * Disallow prototype path override
+ */
+exports.disallowProtoPath = function (path) {
+  if (module.exports.isProtoPath(path)) {
+    throw new Error('Unsafe path encountered: ' + path)
+  }
+}

--- a/packages/grpc-native-core/test/prototype_pollution_test.js
+++ b/packages/grpc-native-core/test/prototype_pollution_test.js
@@ -15,13 +15,12 @@
  *
  */
 
-import * as assert from 'assert';
+var assert = require('assert')
 
 const grpc = require('../');
 
 describe('loadPackageDefinition', () => {
   it('Should not allow prototype pollution', () => {
-      grpc.loadPackageDefinition({'__proto__.polluted': true});
-      assert.notStrictEqual({}.polluted, true);
+      assert.throws(() => grpc.loadPackageDefinition({'__proto__.polluted': true}));
   });
 });


### PR DESCRIPTION
### 📊 Metadata *

`grpc` native core package is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: https://www.huntr.dev/bounties/2-npm-grpc/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

`// poc.js`
`var grpc =require('grpc')`
`grpc.loadPackageDefinition({'constructor.prototype.polluted': { service: "Yes! Its Polluted" }});`
`console.log({}.polluted)`

Execute the following commands in another terminal:

`npm i grpc # Install affected module`
`node poc.js #  Run the PoC`

Check the Output:

[Function: ServiceClient] { service: 'Yes! Its Polluted' }`

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/105854382-d9824780-600c-11eb-9679-e3e5630d0f72.png)

After:
![image](https://user-images.githubusercontent.com/64132745/105854443-ea32bd80-600c-11eb-8354-0352ee61035e.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/106350810-d2ee1b80-62fd-11eb-9c7d-e87566bde068.png)

After the fix, functionality is unaffected.

A breaking change is introduced, the fix wont allow the client to alter and modify the `prototype` properties of an `object`, using the methods `loadPackageDefinition`, `makeClientConstructor ` .

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1792
